### PR TITLE
looping forever and emptying the screen causes characters to be removed from the start

### DIFF
--- a/src/TypeIt.js
+++ b/src/TypeIt.js
@@ -206,7 +206,7 @@ export default function TypeIt(element, options) {
     _queue
       .reset()
       .delete(0)
-      .add([_pause, delay.before], true);
+      .add([_pause, delay.before], 1, true);
 
     // Queue the current number of printed items for deletion.
     _getAllChars().forEach(i => {


### PR DESCRIPTION
When looping and emptying the screen the first element of the queue gets removed and the end of the queue has `undefined` values elements.

I ran the tests and all of them passed, I have also attempted to write a test but couldn't figure out how to do it, mainly because this is a bug that only manifests itself after a few looping rounds.

If you want to give me some ideas of how I could write the test then I can try.

If you want to replicate the bug you can run the following code in the sandbox file.

```
      new TypeIt("#example14", {
        element: "h1",
        waitUntilVisible: true,
        loop: true
      })
        .type("Multiple")
        .break()
        .type("lines")
        .empty()
        .go();
```