### PR TITLE
Cursor movement bug

### DIFF
--- a/__tests__/TypeIt.test.js
+++ b/__tests__/TypeIt.test.js
@@ -109,15 +109,24 @@ describe("go()", () => {
   test("Attaches cursor correctly.", () => {
     expect(document.querySelector(".ti-cursor")).toBeNull();
     instance.go();
-    expect(document.querySelector(".ti-cursor")).not.toBeNull();
+
+    let cursorNode = document.querySelector(".ti-cursor");
+    expect(cursorNode.style.visibility).toEqual("");
+    expect(cursorNode).not.toBeNull();
   });
 
-  test("Does not attach cursor when none should exist.", () => {
+  test("Attaches hidden cursor when option is disabled.", () => {
     args[1].cursor = false;
     instance = new TypeIt(...args);
-    expect(document.querySelector(".ti-cursor")).toBeNull();
+
+    let cursorNode = document.querySelector(".ti-cursor");
+    expect(cursorNode).toBeNull();
     instance.go();
-    expect(document.querySelector(".ti-cursor")).toBeNull();
+
+    cursorNode = document.querySelector(".ti-cursor");
+    expect(cursorNode).not.toBeNull();
+    expect(cursorNode.style.visibility).toEqual("hidden");
+    expect(cursorNode.classList.contains('with-delay')).toBe(false);
   });
 });
 
@@ -207,22 +216,17 @@ describe("break()", () => {
 });
 
 describe("empty()", () => {
-  test("Should empty out element when called with no cursor.", async () => {
+  test("Should empty out element when called with no cursor.", (done) => {
     args[1].cursor = false;
-    instance = new TypeIt(...args);
     element.innerHTML = "existing text";
 
-    await new Promise((resolve) => {
-      args[1].afterComplete = function () {
-        return resolve();
-      };
+    args[1].afterComplete = function () {
+      expect(element.childNodes).toHaveLength(1);
+      done();
+    };
 
-      const instance = new TypeIt(...args);
-
-      instance.empty().go();
-    });
-
-    expect(element.childNodes).toHaveLength(0);
+    const instance = new TypeIt(...args);
+    instance.empty().go();
   });
 
   describe("addSplitPause()", () => {
@@ -322,7 +326,7 @@ describe("reset()", () => {
     expect(element.innerHTML).toEqual("");
   });
 
-  test("Wipes out contents when it's an input.", async () => {
+  test("Wipes out contents when it's an input.", (done) => {
     setHTML`<div>'
       <input id="element">
     </div>`;
@@ -330,19 +334,17 @@ describe("reset()", () => {
     let instance;
     let element = document.querySelector("#element");
 
-    await new Promise((resolve) => {
-      instance = new TypeIt("#element", {
-        speed: 0,
-        strings: "Hi.",
-        afterComplete: () => {
-          resolve();
-        },
-      }).go();
-    });
+    instance = new TypeIt("#element", {
+      speed: 0,
+      strings: "Hi.",
+      afterComplete: () => {
+        expect(element.value).toEqual("Hi.");
+        instance = instance.reset();
+        expect(element.value).toEqual("");
 
-    expect(element.value).toEqual("Hi.");
-    instance = instance.reset();
-    expect(element.value).toEqual("");
+        done();
+      },
+    }).go();
   });
 });
 

--- a/__tests__/helpers/removeEmptyElements.test.js
+++ b/__tests__/helpers/removeEmptyElements.test.js
@@ -34,3 +34,12 @@ test("Break tags should not be removed.", () => {
     '<span id="scope">First line.<br>Second line.<br><br>Third line.</span>'
   );
 });
+
+test("Ignored node should not be removed.", () => {
+  setHTML`<span id="scope">First line.<span class="ti-cursor"></span>Third line.</span>`;
+  removeEmptyElements(document.getElementById("scope"), document.querySelector('.ti-cursor'));
+
+  expect(document.body.innerHTML).toBe(
+    '<span id="scope">First line.<span class="ti-cursor"></span>Third line.</span>'
+  );
+});

--- a/src/helpers/insertIntoElement.ts
+++ b/src/helpers/insertIntoElement.ts
@@ -34,7 +34,7 @@ export const isLastElement = (
 const insertIntoElement = (
   targetElement: Element, // Element we're typing into.
   character: Character, // Character/content we'll be typing.
-  cursorNode: Element | null = null,
+  cursorNode: Element,
   cursorPosition: number
 ) => {
   let contentIsElement = character.content instanceof HTMLElement;
@@ -103,8 +103,6 @@ const insertIntoElement = (
   let lastNode = getAllTypeableNodes(targetElement, cursorNode, true)[cursorPosition - 1];
   let elementToTypeInto = lastNode ? lastNode.parentNode : targetElement;
 
-  // If a cursor node exists, make sure we print BEFORE that, but only if the target
-  // element actually contains it. Otherwise, stick it to the end of the element.
   elementToTypeInto.insertBefore(
     content as Element,
     (elementToTypeInto as Element).contains(cursorNode) ? cursorNode : null

--- a/src/helpers/removeEmptyElements.ts
+++ b/src/helpers/removeEmptyElements.ts
@@ -5,9 +5,9 @@ import removeNode from "./removeNode";
  * Given a DOM scope and selector, remove any HTML element remnants,
  * EXCEPT for <br> tags, which may be typed but do not have any text content.
  */
-export default (node: Element) => {
+export default (node: Element, nodeToIgnore: Element) => {
   node.querySelectorAll("*").forEach((i) => {
-    if (!i.innerHTML && i.tagName !== "BR") {
+    if (!i.innerHTML && i.tagName !== "BR" && !i.isSameNode(nodeToIgnore)) {
       let nodeToRemove = i;
 
       // Traverse up the DOM. If the empty node is the only node

--- a/src/helpers/repositionCursor.ts
+++ b/src/helpers/repositionCursor.ts
@@ -1,18 +1,12 @@
-import { Element } from "../types";
-
 export default (
   element: Node,
   allChars: any[],
   cursor: Node,
   cursorPosition: number
 ): void => {
-  if (!cursor) {
-    return;
-  }
-
-  let characterIndex = cursorPosition > allChars.length
-    ? allChars.length
-    : cursorPosition;
+  // Guarantee that the new cursor position is never greater than
+  // the number of characters we're dealing with.
+  let characterIndex = Math.min(cursorPosition, allChars.length);
 
   let nodeToInsertBefore = allChars[characterIndex - 1];
 


### PR DESCRIPTION
# Description

Fixes issue #236, which was preventing the `move()` method from working unless the `cursor` option was enabled. 

## Impact

In the interest of maintainability, the fix for this bug involves ALWAYS mounting a cursor node to the DOM, for easy tracking of where continued typing should occur. When the `cursor` option is disabled, that mounted node will simply be empty & made invisible. That way, it will still be able to used as the reference point when typing, deleting, etc. 

The alternative would've involved storing a reference to the typing position in memory, which would have been far more complicated to implement. 

## Type of Change

[x] It's a bug fix.