### PR TITLE
Typeitreact - Add type to TypeItOptions

### DIFF
--- a/packages/typeit-react/src/index.d.ts
+++ b/packages/typeit-react/src/index.d.ts
@@ -1,6 +1,20 @@
 import * as React from 'react';
 export interface TypeItOptions {
     strings?: Array<string> | string;
+    speed?: number;
+    deleteSpeed?: number | null;
+    lifeLike?: boolean;
+    cursor?: boolean;
+    cursorSpeed?: number;
+    cursorChar?: string;
+    breakLines?: boolean;
+    nextStringDelay?: Array<number> | number;
+    waitUntilVisible?: boolean;
+    startDelete?: boolean;
+    startDelay?: boolean;
+    loop?: boolean;
+    loopDelay?: Array<number> | number;
+    html?: boolean;
 }
 export interface TypeItProps {
     as?: keyof JSX.IntrinsicElements;


### PR DESCRIPTION
# Description

I get an error when using the package with create-react-app (typescript-template). Typescript compiler complains about missing types.  The component works fine when I close the error modal but I am unable to build my projects. To fix my issue I added manually the types with [patch-package](https://www.npmjs.com/package/patch-package).

![typeit_error_type_create_react_app](https://user-images.githubusercontent.com/60394608/146262908-e728d4ae-58a5-4560-8b5a-426c9ea3f2d1.png)

## Type of Change

Bug Fix
Update TypeItOptions interface

## Checklist

Update TypeItOptions interface referring the doc of the vanila-js package =>https://typeitjs.com/docs/vanilla/usage#configuration-options.

Sorry but I couldn't run the tests, I got this error message. (First Time Contributing)
![error_test](https://user-images.githubusercontent.com/60394608/146263498-c511673d-c383-432a-bb32-44d7d0d1150f.png)

## License Agreement

By submitting this code, I'm aware that, if merged, it will be used as part of a commercial project. By submitting this pull request, I am aware that I'm giving my consent for my code to become a part of TypeIt or any of its related packages, and for it to be used and sold commercially.
