### PR TITLE
Allow queue to be rebuilt when instance is reset.

### DIFF
--- a/packages/typeit/__tests__/TypeIt.test.js
+++ b/packages/typeit/__tests__/TypeIt.test.js
@@ -391,6 +391,33 @@ describe("reset()", () => {
       },
     }).go();
   });
+
+  describe("rebuilder function is provided", () => {
+    test("Rebuilds queue and executes it if specified.", (done) => {
+      setHTML`<div>
+        <span id="element"></span>
+      </div>`;
+
+      let hasCompletedOnce = false;
+      let el = document.querySelector("#element");
+      let instance = new TypeIt("#element", {
+        speed: 0,
+        afterComplete: () => {
+          // After the second "run," the HTML should contain whatever the
+          // second rebuilt queue instructed to run.
+          if (hasCompletedOnce) {
+            expect(el.innerHTML).toMatch(/^second<span/);
+            return done();
+          }
+
+          instance.reset((i) => i.type("second")).go();
+          hasCompletedOnce = true;
+        },
+      })
+        .type("first")
+        .go();
+    });
+  });
 });
 
 describe("destroy()", () => {

--- a/packages/typeit/src/Queue.ts
+++ b/packages/typeit/src/Queue.ts
@@ -29,10 +29,16 @@ const Queue = function (initialItems: QueueItem[]) {
     });
   };
 
+  const wipe = function (): void {
+    _queue = [];
+    add(initialItems); 
+  }
+
   /**
-   * Retrieve all items that are still eligible to be executed.
+   * Retrieve all items that are still eligible to be executed. By default, only the 
+   * completed items will be retrieved. 
    */
-  const getItems = (): QueueItem[] => _queue.filter(i => !i.done);
+  const getItems = (all: boolean = false): QueueItem[] => _queue.filter(i => all || !i.done);
 
   const markDone = (index: number) => {
     _queue[index].done = true;
@@ -46,6 +52,7 @@ const Queue = function (initialItems: QueueItem[]) {
     add,
     set,
     reset,
+    wipe,
     getItems,
     markDone,
   };

--- a/packages/typeit/src/index.ts
+++ b/packages/typeit/src/index.ts
@@ -527,10 +527,16 @@ export default function TypeIt(
 
   this.unfreeze = function () {};
 
-  this.reset = function () {
+  this.reset = function (rebuild: ((TypeIt) => typeof TypeIt) | undefined) {
     !this.is("destroyed") && this.destroy();
 
-    _queue.reset();
+    // If provided, the queue can be totally regenerated.
+    if(rebuild) {
+      _queue.wipe();
+      rebuild(this);
+    } else {  
+      _queue.reset();
+    }
 
     _cursorPosition = 0;
 


### PR DESCRIPTION
Permits a queue to be rebuilt on `.reset()`. 