### PR TITLE
[Bug Fix] Remove all content when `startDelete` is enabled.

### DIFF
--- a/packages/typeit/package.json
+++ b/packages/typeit/package.json
@@ -17,7 +17,7 @@
     "scripts/"
   ],
   "scripts": {
-    "build": "vite build && ./scripts/banner && tsc",
+    "build": "vite build && scripts/banner && tsc",
     "tsc": "tsc",
     "start": "vite serve examples",
     "test": "jest",

--- a/packages/typeit/package.json
+++ b/packages/typeit/package.json
@@ -17,7 +17,7 @@
     "scripts/"
   ],
   "scripts": {
-    "build": "vite build && scripts/banner && tsc",
+    "build": "vite build && ./scripts/banner && tsc",
     "tsc": "tsc",
     "start": "vite serve examples",
     "test": "jest",

--- a/packages/typeit/src/index.ts
+++ b/packages/typeit/src/index.ts
@@ -322,7 +322,7 @@ const TypeIt: TypeItInstance = function (element, options = {}) {
     if (_elementIsInput()) {
       _element.value = (_element.value as string).slice(0, -1);
     } else {
-      removeNode(allChars[_cursorPosition]);
+      _getAllChars().forEach(removeNode);
     }
   };
 


### PR DESCRIPTION
# Description

Fix https://github.com/alexmacarthur/typeit/issues/301

## Type of Change

- [x] It's a bug fix.
- [ ] It's a new feature (without breaking changes). 
- [ ] It's a breaking change.

## Checklist

- [x] Provided detailed description of the issue above. 
- [x] Updated tests where appropriate.

## License Agreement

- [x] By submitting this code, I'm aware that, if merged, it will be used as part of a commercial project. By submitting this pull request, I am aware that I'm giving my consent for my code to become a part of TypeIt or any of its related packages, and for it to be used and sold commercially.
