### PR TITLE
:tada: Full EMOJI Support! :tada:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 node_modules
 dist/
+.idea/

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ For more advanced, controlled typing effects, TypeIt comes with companion functi
 -   Define strings programmatically or directly in the HTML (a useful fallback in case user doesn't have JavaScript enabled, as well as for SEO).
 -   Handle HTML (even nested tags!) with ease, preserving all of its attributes (classes, ids, etc.).
 -   Offered as an ES module for modern bundlers, or a UMD library for loading via a traditional `<script>` tags.
+-   Can optionally support ➡️ 🔥 Emojis 🔥 ⬅️ and other Graphemes with [orling/grapheme-splitter](https://github.com/orling/grapheme-splitter)!
 
 ## License Options
 

--- a/packages/typeit-react/package-lock.json
+++ b/packages/typeit-react/package-lock.json
@@ -1,17 +1,16 @@
 {
   "name": "typeit-react",
-  "version": "2.6.2",
+  "version": "2.6.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "typeit-react",
-      "version": "2.6.2",
+      "version": "2.6.4",
       "license": "GPL-3.0",
       "dependencies": {
         "react": ">=17.0.0",
-        "react-dom": ">=17.0.0",
-        "typeit": "^8.7.1"
+        "react-dom": ">=17.0.0"
       },
       "devDependencies": {
         "@babel/preset-typescript": "^7.18.6",
@@ -1465,12 +1464,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/typeit": {
-      "version": "8.7.1",
-      "resolved": "https://registry.npmjs.org/typeit/-/typeit-8.7.1.tgz",
-      "integrity": "sha512-Bx/O4NMz10NWh9FWYtVwV4XwGHF9UDJfpCZPJRtw2/oUcahFAStU8J0t19aroPfTV6s1UlS5ICoqilOqmEnh2Q==",
-      "hasInstallScript": true
-    },
     "node_modules/typescript": {
       "version": "4.9.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
@@ -2527,11 +2520,6 @@
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
       "dev": true
-    },
-    "typeit": {
-      "version": "8.7.1",
-      "resolved": "https://registry.npmjs.org/typeit/-/typeit-8.7.1.tgz",
-      "integrity": "sha512-Bx/O4NMz10NWh9FWYtVwV4XwGHF9UDJfpCZPJRtw2/oUcahFAStU8J0t19aroPfTV6s1UlS5ICoqilOqmEnh2Q=="
     },
     "typescript": {
       "version": "4.9.4",

--- a/packages/typeit/__tests__/__snapshots__/TypeIt.test.js.snap
+++ b/packages/typeit/__tests__/__snapshots__/TypeIt.test.js.snap
@@ -540,6 +540,7 @@ exports[`reset() Successfully resets when called. 1`] = `
   "speed": 100,
   "startDelay": 250,
   "startDelete": false,
+  "stringSpliterator": [Function],
   "strings": [
     "This is my string!",
   ],

--- a/packages/typeit/__tests__/helpers/__snapshots__/chunkStrings.test.js.snap
+++ b/packages/typeit/__tests__/helpers/__snapshots__/chunkStrings.test.js.snap
@@ -355,6 +355,42 @@ exports[`maybeChunkStringAsHtml() Should correctly transform non-HTML string as 
 ]
 `;
 
+exports[`maybeChunkStringAsHtml() Should return correctly split string with emoji. 1`] = `
+[
+  A,
+  n,
+   ,
+  🍕,
+   ,
+  e,
+  m,
+  o,
+  j,
+  i,
+   ,
+  🌷,
+   ,
+  f,
+  i,
+  l,
+  l,
+  e,
+  d,
+   ,
+  👍,
+   ,
+  s,
+  t,
+  r,
+  i,
+  n,
+  g,
+  .,
+   ,
+  ⬆️,
+]
+`;
+
 exports[`maybeChunkStringAsHtml() Should return noderized string when setting is enabled. 1`] = `
 [
   A,

--- a/packages/typeit/__tests__/helpers/countStepsToSelector.test.js
+++ b/packages/typeit/__tests__/helpers/countStepsToSelector.test.js
@@ -1,9 +1,10 @@
 import countStepsToSelector from "../../src/helpers/countStepsToSelector";
 import { chunkStringAsHtml } from "../../src/helpers/chunkStrings";
 import Queue from "../../src/Queue";
+import { DEFAULT_OPTIONS } from "../../src/constants";
 
 let buildQueueFromString = (str) => {
-  let chunks = chunkStringAsHtml(str);
+  let chunks = chunkStringAsHtml(str, DEFAULT_OPTIONS.stringSpliterator);
   let queue = new Queue([]);
 
   chunks.forEach((char) => {

--- a/packages/typeit/__tests__/helpers/expandTextNodes.test.js
+++ b/packages/typeit/__tests__/helpers/expandTextNodes.test.js
@@ -1,7 +1,12 @@
 import expandTextNodes from "../../src/helpers/expandTextNodes";
+import { DEFAULT_OPTIONS } from "../../src/constants";
 
 const getTextNodes = (element) => {
   return [...element.childNodes].filter((n) => n.nodeType === 3);
+};
+
+const defaultExpandTextNodes = (element) => {
+  return expandTextNodes(element, DEFAULT_OPTIONS.stringSpliterator);
 };
 
 describe("simple content", () => {
@@ -9,7 +14,7 @@ describe("simple content", () => {
     setHTML(`<span>hello</span>`);
 
     const element = document.querySelector("span");
-    expandTextNodes(element);
+    defaultExpandTextNodes(element);
 
     expect(element.childNodes).toHaveLength(5);
     expect(element.innerHTML).toEqual("hello");
@@ -21,7 +26,7 @@ describe("simple HTML", () => {
     setHTML(`<span>hello, <strong>pal!</strong></span>`);
 
     const element = document.querySelector("span");
-    expandTextNodes(element);
+    defaultExpandTextNodes(element);
 
     expect(getTextNodes(element)).toHaveLength(7);
     expect(getTextNodes(element.querySelector("strong"))).toHaveLength(4);
@@ -34,7 +39,7 @@ describe("nested HTML", () => {
     setHTML(`<span>hello, <strong>there, <em>pal!</em></strong></span>`);
 
     const element = document.querySelector("span");
-    expandTextNodes(element);
+    defaultExpandTextNodes(element);
 
     expect(getTextNodes(element)).toHaveLength(7);
     expect(getTextNodes(element.querySelector("strong"))).toHaveLength(7);
@@ -50,7 +55,7 @@ describe("emojis", () => {
     setHTML(`<span>good job 👍.</span>`);
 
     const element = document.querySelector("span");
-    expandTextNodes(element);
+    defaultExpandTextNodes(element);
 
     expect(getTextNodes(element)).toHaveLength(11);
     expect(element.innerHTML).toEqual("good job 👍.");

--- a/packages/typeit/__tests__/helpers/getAllChars.test.js
+++ b/packages/typeit/__tests__/helpers/getAllChars.test.js
@@ -1,15 +1,28 @@
 import getAllChars from "../../src/helpers/getAllChars";
 import expandTextNodes from "../../src/helpers/expandTextNodes";
+import GraphemeSplitter from "grapheme-splitter";
+import { defaultExpandTextNodes, defaultGetAllChars } from "./util";
 
 describe("element is an input", () => {
-  setHTML`
+  test("it should return the input contents", () => {
+    setHTML`
         <input id="el" type="text" value="hello!" />
     `;
 
-  test("it should return the input contents", () => {
-    const result = getAllChars(document.getElementById("el"));
+    const result = defaultGetAllChars(document.getElementById("el"));
 
     expect(result).toEqual(["h", "e", "l", "l", "o", "!"]);
+  });
+  test("it should return the input contents when containing emoji", () => {
+    setHTML`
+        <input id="el" type="text" value="⬆️ m̅" />
+    `;
+    const splitter = new GraphemeSplitter();
+    const result = getAllChars(document.getElementById("el"), (str) =>
+      splitter.splitGraphemes(str)
+    );
+
+    expect(result).toEqual(["⬆️", " ", "m̅"]);
   });
 });
 
@@ -19,9 +32,9 @@ describe("element is not an element", () => {
             <span id="el">howdy.</span>
         `;
 
-    expandTextNodes(document.getElementById("el"));
+    defaultExpandTextNodes(document.getElementById("el"));
 
-    const result = getAllChars(document.getElementById("el"));
+    const result = defaultGetAllChars(document.getElementById("el"));
 
     expect(result.map((n) => n.nodeValue)).toEqual([
       ".",
@@ -33,14 +46,49 @@ describe("element is not an element", () => {
     ]);
   });
 
+  test("it should return simple contents correctly when emoji are present", () => {
+    setHTML`
+            <span id="el">👍 howdy 🤯 🌷 Ĺo͂řȩm̅</span>
+        `;
+    const splitter = new GraphemeSplitter();
+
+    expandTextNodes(document.getElementById("el"), (str) =>
+      splitter.splitGraphemes(str)
+    );
+
+    const result = getAllChars(document.getElementById("el"), (str) =>
+      splitter.splitGraphemes(str)
+    );
+
+    expect(result.map((n) => n.nodeValue)).toEqual([
+      "m̅",
+      "ȩ",
+      "ř",
+      "o͂",
+      "Ĺ",
+      " ",
+      "🌷",
+      " ",
+      "🤯",
+      " ",
+      "y",
+      "d",
+      "w",
+      "o",
+      "h",
+      " ",
+      "👍",
+    ]);
+  });
+
   test("it should ignore cursor", () => {
     setHTML`
             <span id="el">greet<i class="ti-cursor">|</i>ings!</span>
         `;
 
-    expandTextNodes(document.getElementById("el"));
+    defaultExpandTextNodes(document.getElementById("el"));
 
-    const result = getAllChars(document.getElementById("el"));
+    const result = defaultGetAllChars(document.getElementById("el"));
 
     expect(result.map((n) => n.nodeValue)).toEqual([
       "!",

--- a/packages/typeit/__tests__/helpers/getParsedBody.test.js
+++ b/packages/typeit/__tests__/helpers/getParsedBody.test.js
@@ -1,20 +1,36 @@
 import getParsedBody from "../../src/helpers/getParsedBody";
+import GraphemeSplitter from "grapheme-splitter";
+import { defaultGetParsedBody, emojiFiveDigitString } from "./util";
 
 test("Returns body from empty string.", () => {
   let string = "";
-  let result = getParsedBody(string);
+  let result = defaultGetParsedBody(string);
   expect(result.tagName).toEqual("BODY");
   expect(result.childNodes.length).toBe(0);
 });
 
 test("Returns body from simple string.", () => {
   let string = "This is a string.";
-  let result = getParsedBody(string);
+  let result = defaultGetParsedBody(string);
   expect(result.childNodes.length).toBe(17);
 });
 
 test("Returns body from string containing HTML.", () => {
   let string = "This is a <strong>string</strong>.";
-  let result = getParsedBody(string);
+  let result = defaultGetParsedBody(string);
   expect(result.childNodes.length).toBe(12);
+});
+
+test("Returns body from emoji Konami Code.", () => {
+  let string = "⬆️⬆️⬇️⬇️⬅️➡️⬅️➡️🅱️🅰️🏁";
+  let splitter = new GraphemeSplitter();
+  let result = getParsedBody(string, (str) => splitter.splitGraphemes(str));
+  expect(result.childNodes.length).toBe(11);
+});
+
+test("Returns body from emoji numbers.", () => {
+  let string = emojiFiveDigitString;
+  let splitter = new GraphemeSplitter();
+  let result = getParsedBody(string, (str) => splitter.splitGraphemes(str));
+  expect(result.childNodes.length).toBe(5);
 });

--- a/packages/typeit/__tests__/helpers/insertIntoElement.test.js
+++ b/packages/typeit/__tests__/helpers/insertIntoElement.test.js
@@ -1,7 +1,6 @@
 import insertIntoElement from "../../src/helpers/insertIntoElement";
-import getParsedBody from "../../src/helpers/getParsedBody";
 import { walkElementNodes } from "../../src/helpers/chunkStrings";
-import expandTextNodes from "../../src/helpers/expandTextNodes";
+import { defaultExpandTextNodes, defaultGetParsedBody } from "./util";
 
 describe("an input", () => {
   it("inserts text into blank input", () => {
@@ -39,7 +38,7 @@ describe("plain text", () => {
     setHTML`<span id="el"><i class="ti-cursor">|</i></span>`;
     const el = document.body;
 
-    const body = getParsedBody('<span id="el"><em>a</em></span>');
+    const body = defaultGetParsedBody('<span id="el"><em>a</em></span>');
     const em = body.querySelector("em");
     em.originalParent = document.querySelector("#el");
 
@@ -61,10 +60,10 @@ describe("plain text", () => {
     setHTML`<span id="top"><i class="ti-cursor">|</i></span>`;
     const el = document.querySelector("#top");
 
-    const spanEl = getParsedBody(
+    const spanEl = defaultGetParsedBody(
       'a<em id="middle">b<strong id="bottom">c</strong></em>'
     );
-    const nodes = walkElementNodes(expandTextNodes(spanEl));
+    const nodes = walkElementNodes(defaultExpandTextNodes(spanEl));
 
     nodes.forEach((n) => {
       insertIntoElement(el, n);
@@ -79,8 +78,8 @@ describe("plain text", () => {
     setHTML`<span id="top"><i class="ti-cursor">|</i></span>`;
     const el = document.querySelector("#top");
 
-    const spanEl = getParsedBody("a<br/>b<br/>c</em>");
-    const nodes = walkElementNodes(expandTextNodes(spanEl));
+    const spanEl = defaultGetParsedBody("a<br/>b<br/>c</em>");
+    const nodes = walkElementNodes(defaultExpandTextNodes(spanEl));
 
     spanEl.querySelectorAll("br").forEach((b) => {
       delete b.originalParent;

--- a/packages/typeit/__tests__/helpers/repositionCursor.test.js
+++ b/packages/typeit/__tests__/helpers/repositionCursor.test.js
@@ -1,44 +1,91 @@
 import repositionCursor from "../../src/helpers/repositionCursor";
 import { walkElementNodes } from "../../src/helpers/chunkStrings";
 import expandTextNodes from "../../src/helpers/expandTextNodes";
+import { defaultExpandTextNodes, emojiFiveDigitString } from "./util";
+import GraphemeSplitter from "grapheme-splitter";
 
 let element, allCharacters;
 
-beforeEach(() => {
-  setHTML`<span id="el">12345<i class="ti-cursor">|</i></span>`;
+describe("cursor movement default charset", () => {
+  beforeEach(() => {
+    setHTML`<span id="el">12345<i class="ti-cursor">|</i></span>`;
 
-  element = expandTextNodes(document.querySelector("#el"));
+    element = defaultExpandTextNodes(document.querySelector("#el"));
 
-  allCharacters = walkElementNodes(element, true);
+    allCharacters = walkElementNodes(element, true);
+  });
+
+  it("Does not move cursor when stepsToMove is zero.", () => {
+    repositionCursor(element, allCharacters, 0);
+
+    let expected = `<span id="el">12345<i class="ti-cursor">|</i></span>`;
+    expect(document.body.innerHTML).toEqual(expected);
+  });
+
+  it("Moves cursor three steps back.", () => {
+    repositionCursor(element, allCharacters, 3);
+
+    let expected = `<span id="el">12<i class="ti-cursor">|</i>345</span>`;
+
+    expect(document.body.innerHTML).toEqual(expected);
+  });
+
+  it("Moves cursor three back and two forward.", () => {
+    repositionCursor(element, allCharacters, 3);
+
+    repositionCursor(element, allCharacters, 1);
+
+    let expected = `<span id="el">1234<i class="ti-cursor">|</i>5</span>`;
+    expect(document.body.innerHTML).toEqual(expected);
+  });
+
+  it("Stops moving when at end of string.", () => {
+    repositionCursor(element, allCharacters, -100);
+
+    let expected = `<span id="el">12345<i class="ti-cursor">|</i></span>`;
+    expect(document.body.innerHTML).toEqual(expected);
+  });
 });
 
-test("Does not move cursor when stepsToMove is zero.", () => {
-  repositionCursor(element, allCharacters, 0);
+describe("cursor movement emoji", () => {
+  beforeEach(() => {
+    // Set the HTML raw to avoid pre-processing of the emoji.
+    document.body.innerHTML = `<span id="el">${emojiFiveDigitString}<i class="ti-cursor">|</i></span>`;
+    const splitter = new GraphemeSplitter();
+    element = expandTextNodes(document.querySelector("#el"), (str) =>
+      splitter.splitGraphemes(str)
+    );
 
-  let expected = `<span id="el">12345<i class="ti-cursor">|</i></span>`;
-  expect(document.body.innerHTML).toEqual(expected);
-});
+    allCharacters = walkElementNodes(element, true);
+  });
+  it("Does not move cursor when stepsToMove is zero.", () => {
+    repositionCursor(element, allCharacters, 0);
 
-test("Moves cursor three steps back.", () => {
-  repositionCursor(element, allCharacters, 3);
+    let expected = `<span id="el">1️⃣2️⃣3️⃣4️⃣5️⃣<i class="ti-cursor">|</i></span>`;
+    expect(document.body.innerHTML).toEqual(expected);
+  });
 
-  let expected = `<span id="el">12<i class="ti-cursor">|</i>345</span>`;
+  it("Moves cursor three steps back.", () => {
+    repositionCursor(element, allCharacters, 3);
 
-  expect(document.body.innerHTML).toEqual(expected);
-});
+    let expected = `<span id="el">1️⃣2️⃣<i class="ti-cursor">|</i>3️⃣4️⃣5️⃣</span>`;
 
-test("Moves cursor three back and two forward.", () => {
-  repositionCursor(element, allCharacters, 3);
+    expect(document.body.innerHTML).toEqual(expected);
+  });
 
-  repositionCursor(element, allCharacters, 1);
+  it("Moves cursor three back and two forward.", () => {
+    repositionCursor(element, allCharacters, 3);
 
-  let expected = `<span id="el">1234<i class="ti-cursor">|</i>5</span>`;
-  expect(document.body.innerHTML).toEqual(expected);
-});
+    repositionCursor(element, allCharacters, 1);
 
-test("Stops moving when at end of string.", () => {
-  repositionCursor(element, allCharacters, -100);
+    let expected = `<span id="el">1️⃣2️⃣3️⃣4️⃣<i class="ti-cursor">|</i>5️⃣</span>`;
+    expect(document.body.innerHTML).toEqual(expected);
+  });
 
-  let expected = `<span id="el">12345<i class="ti-cursor">|</i></span>`;
-  expect(document.body.innerHTML).toEqual(expected);
+  it("Stops moving when at end of string.", () => {
+    repositionCursor(element, allCharacters, -100);
+
+    let expected = `<span id="el">${emojiFiveDigitString}<i class="ti-cursor">|</i></span>`;
+    expect(document.body.innerHTML).toEqual(expected);
+  });
 });

--- a/packages/typeit/__tests__/helpers/util.js
+++ b/packages/typeit/__tests__/helpers/util.js
@@ -1,0 +1,34 @@
+import getParsedBody from "../../src/helpers/getParsedBody";
+import { DEFAULT_OPTIONS } from "../../src/constants";
+import getAllChars from "../../src/helpers/getAllChars";
+import expandTextNodes from "../../src/helpers/expandTextNodes";
+import {
+  chunkStringAsHtml,
+  maybeChunkStringAsHtml,
+} from "../../src/helpers/chunkStrings";
+
+export const emojiFiveDigitString = "1️⃣2️⃣3️⃣4️⃣5️⃣";
+
+export const defaultGetParsedBody = (content) => {
+  return getParsedBody(content, DEFAULT_OPTIONS.stringSpliterator);
+};
+
+export const defaultGetAllChars = (el) => {
+  return getAllChars(el, DEFAULT_OPTIONS.stringSpliterator);
+};
+
+export const defaultChunkStringAsHtml = (string) => {
+  return chunkStringAsHtml(string, DEFAULT_OPTIONS.stringSpliterator);
+};
+
+export const defaultMaybeChunkStringAsHtml = (string, asHtml = true) => {
+  return maybeChunkStringAsHtml(
+    string,
+    asHtml,
+    DEFAULT_OPTIONS.stringSpliterator
+  );
+};
+
+export const defaultExpandTextNodes = (el) => {
+  return expandTextNodes(el, DEFAULT_OPTIONS.stringSpliterator);
+};

--- a/packages/typeit/examples/examples.ts
+++ b/packages/typeit/examples/examples.ts
@@ -1,4 +1,5 @@
 import TypeIt from "../src";
+import GraphemeSplitter from "grapheme-splitter";
 
 new TypeIt("#crazy-cursor", {
   speed: 50,
@@ -257,3 +258,21 @@ new TypeIt("#start-delete", {
   startDelete: true,
   loop: true,
 }).go();
+
+const splitter = new GraphemeSplitter();
+new TypeIt("#emoji", {
+  startDelete: true,
+  loop: true,
+  stringSpliterator: (string) => splitter.splitGraphemes(string),
+})
+  .type("👋🏻")
+  .break()
+  .type("⬆️⬆️⬇️⬇️⬅️➡️⬅️➡️🅱️🅰️🏁")
+  .delete(3)
+  .break()
+  .type("👋🏻")
+  .move(-2)
+  .type("🅱️🅰️🏁")
+  .move(2)
+  .pause(10)
+  .go();

--- a/packages/typeit/examples/index.html
+++ b/packages/typeit/examples/index.html
@@ -161,6 +161,13 @@
         <h3 id="start-delete">This IS hard-coded!</h3>
       </form>
     </section>
+
+    <section>
+      <h2>Emoji Support</h2>
+      <form>
+        <h3 id="emoji"></h3>
+      </form>
+    </section>
   </div>
 
   <script type="module" src="./examples.ts"></script>

--- a/packages/typeit/package-lock.json
+++ b/packages/typeit/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "typeit",
-  "version": "8.7.0",
+  "version": "8.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "typeit",
-      "version": "8.7.0",
+      "version": "8.7.1",
       "hasInstallScript": true,
       "license": "GPL-3.0",
       "devDependencies": {
         "@babel/preset-env": "^7.20.2",
         "@babel/preset-typescript": "^7.18.6",
         "@types/web-animations-js": "^2.2.12",
+        "grapheme-splitter": "^1.0.4",
         "jest": "^29.3.1",
         "jest-cli": "^29.3.1",
         "jest-environment-jsdom": "^29.3.1",
@@ -3967,6 +3968,12 @@
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
       "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+      "dev": true
+    },
+    "node_modules/grapheme-splitter": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
       "dev": true
     },
     "node_modules/has": {
@@ -10205,6 +10212,12 @@
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
       "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+      "dev": true
+    },
+    "grapheme-splitter": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
       "dev": true
     },
     "has": {

--- a/packages/typeit/package.json
+++ b/packages/typeit/package.json
@@ -42,6 +42,7 @@
     "@babel/preset-env": "^7.20.2",
     "@babel/preset-typescript": "^7.18.6",
     "@types/web-animations-js": "^2.2.12",
+    "grapheme-splitter": "^1.0.4",
     "jest": "^29.3.1",
     "jest-cli": "^29.3.1",
     "jest-environment-jsdom": "^29.3.1",
@@ -52,10 +53,12 @@
   "jest": {
     "clearMocks": true,
     "testPathIgnorePatterns": [
-      "<rootDir>/__tests__/setup.js"
+      "<rootDir>/__tests__/setup.js",
+      "<rootDir>/__tests__/helpers/util.js"
     ],
     "setupFilesAfterEnv": [
-      "./__tests__/setup.js"
+      "./__tests__/setup.js",
+      "./__tests__/helpers/util.js"
     ],
     "testEnvironment": "jsdom"
   }

--- a/packages/typeit/src/constants.ts
+++ b/packages/typeit/src/constants.ts
@@ -1,4 +1,5 @@
 import { CursorOptions, Options } from "./types";
+import toArray from "./helpers/toArray";
 
 export const DATA_ATTRIBUTE = "data-typeit-id";
 export const CURSOR_CLASS = "ti-cursor";
@@ -41,6 +42,7 @@ export const DEFAULT_OPTIONS: Options & {
   startDelay: 250,
   startDelete: false,
   strings: [],
+  stringSpliterator: (str) => toArray(str),
   waitUntilVisible: false,
   beforeString: () => {},
   afterString: () => {},

--- a/packages/typeit/src/helpers/chunkStrings.ts
+++ b/packages/typeit/src/helpers/chunkStrings.ts
@@ -53,8 +53,11 @@ export function walkElementNodes(
  * Convert string to array of chunks that will be later
  * used to construct a TypeIt queue.
  */
-export function chunkStringAsHtml(string: string): El[] {
-  return walkElementNodes(getParsedBody(string));
+export function chunkStringAsHtml(
+  string: string,
+  stringSpliterator: (str: string) => string[]
+): El[] {
+  return walkElementNodes(getParsedBody(string, stringSpliterator));
 }
 
 /**
@@ -63,11 +66,15 @@ export function chunkStringAsHtml(string: string): El[] {
  *
  * @param {string} str
  * @param {boolean} asHtml
+ * @param {(string) => string[]}stringSpliterator
  * @return {array}
  */
 export function maybeChunkStringAsHtml(
   str: string,
-  asHtml = true
+  asHtml = true,
+  stringSpliterator: (str: string) => string[]
 ): Partial<El>[] {
-  return asHtml ? chunkStringAsHtml(str) : toArray(str).map(createTextNode);
+  return asHtml
+    ? chunkStringAsHtml(str, stringSpliterator)
+    : toArray(stringSpliterator(str)).map(createTextNode);
 }

--- a/packages/typeit/src/helpers/expandTextNodes.ts
+++ b/packages/typeit/src/helpers/expandTextNodes.ts
@@ -1,10 +1,13 @@
 import createTextNode from "./createTextNode";
 import { El } from "../types";
 
-let expandTextNodes = (element: El): El => {
+const expandTextNodes = (
+  element: El,
+  stringSpliterator: (str: string) => string[]
+): El => {
   [...element.childNodes].forEach((child) => {
     if (child.nodeValue) {
-      [...child.nodeValue].forEach((c) => {
+      stringSpliterator(child.nodeValue).forEach((c) => {
         child.parentNode.insertBefore(createTextNode(c), child);
       });
 
@@ -12,7 +15,7 @@ let expandTextNodes = (element: El): El => {
       return;
     }
 
-    expandTextNodes(child as El);
+    expandTextNodes(child as El, stringSpliterator);
   });
 
   return element;

--- a/packages/typeit/src/helpers/getAllChars.ts
+++ b/packages/typeit/src/helpers/getAllChars.ts
@@ -7,9 +7,16 @@ import { walkElementNodes } from "./chunkStrings";
  * Get a flattened array of text nodes that have been typed.
  * This excludes any cursor character that might exist.
  */
-let getAllChars = (element: El) => {
+let getAllChars = (
+  element: El,
+  stringSpliterator: (str: string) => string[]
+) => {
   if (isInput(element)) {
-    return toArray(element.value);
+    if (typeof element.value === "string") {
+      return toArray(stringSpliterator(element.value));
+    } else {
+      return toArray(element.value);
+    }
   }
 
   return walkElementNodes(element, true).filter(

--- a/packages/typeit/src/helpers/getParsedBody.ts
+++ b/packages/typeit/src/helpers/getParsedBody.ts
@@ -5,9 +5,9 @@ import expandTextNodes from "./expandTextNodes";
  * Parse a string as HTML and return the body
  * of the parsed document, with all text nodes expanded.
  */
-export default (content): El => {
+export default (content, stringSpliterator: (str: string) => string[]): El => {
   let doc = document.implementation.createHTMLDocument();
   doc.body.innerHTML = content;
 
-  return expandTextNodes(doc.body as El);
+  return expandTextNodes(doc.body as El, stringSpliterator);
 };

--- a/packages/typeit/src/index.ts
+++ b/packages/typeit/src/index.ts
@@ -88,7 +88,7 @@ const TypeIt: TypeItInstance = function (element, options = {}) {
 
   let _getPace = (index: number = 0): number => calculatePace(_opts)[index];
 
-  let _getAllChars = (): El[] => getAllChars(_element);
+  let _getAllChars = (): El[] => getAllChars(_element, _opts.stringSpliterator);
 
   let _maybeAppendPause = (opts: ActionOpts = {}) => {
     let delay = opts.delay;
@@ -145,7 +145,10 @@ const TypeIt: TypeItInstance = function (element, options = {}) {
       return cursor as El;
     }
 
-    cursor.innerHTML = getParsedBody(_opts.cursorChar).innerHTML;
+    cursor.innerHTML = getParsedBody(
+      _opts.cursorChar,
+      _opts.stringSpliterator
+    ).innerHTML;
 
     return cursor as El;
   };
@@ -253,7 +256,7 @@ const TypeIt: TypeItInstance = function (element, options = {}) {
     if (_opts.startDelete) {
       _element.innerHTML = existingMarkup;
 
-      expandTextNodes(_element);
+      expandTextNodes(_element, _opts.stringSpliterator);
 
       _addSplitPause(
         duplicate(
@@ -537,7 +540,11 @@ const TypeIt: TypeItInstance = function (element, options = {}) {
 
     let { instant } = actionOpts;
     let bookEndQueueItems = _generateTemporaryOptionQueueItems(actionOpts);
-    let chars = maybeChunkStringAsHtml(string, _opts.html);
+    let chars = maybeChunkStringAsHtml(
+      string,
+      _opts.html,
+      _opts.stringSpliterator
+    );
 
     let charsAsQueueItems = chars.map((char): QueueItem => {
       return {

--- a/packages/typeit/src/types.ts
+++ b/packages/typeit/src/types.ts
@@ -33,6 +33,22 @@ export interface Options {
   startDelay?: number;
   startDelete?: boolean;
   strings?: string[] | string;
+  /**
+   * String splitter function, can be used to split emoji's or graphemes.
+   *
+   * @example
+   * ```js
+   * import GraphemeSplitter from "grapheme-splitter";
+   * const splitter = new GraphemeSplitter();
+   * new TypeIt("#element", {
+   *   strings: "👋🏻👋🏼👋🏽👋🏾👋🏿",
+   *   stringSpliterator: (str) => splitter.splitGraphemes(str),
+   * });
+   * ```
+   * @see https://www.npmjs.com/package/grapheme-splitter
+   * @default null
+   */
+  stringSpliterator?: (str: string) => string[];
   waitUntilVisible?: boolean;
   beforeString?: Function;
   afterString?: Function;


### PR DESCRIPTION
Adds a `stringSpliterator` function option to the `Options`

This allows custom string spliterators to be supported;
as an example: https://www.npmjs.com/package/grapheme-splitter

Signed-off-by: Jonathan Leitschuh <Jonathan.Leitschuh@gmail.com>

# Description

_Please include demo links, if possible!_

## Type of Change

[] It's a bug fix.
[x] It's a new feature (without breaking changes). [] It's a breaking change.

## Checklist

Closes #343
Closes #208

[x] Provided detailed description of the issue above. [x] Updated tests where appropriate.

## License Agreement

[x] By submitting this code, I'm aware that, if merged, it will be used as part of a commercial project. By submitting this pull request, I am aware that I'm giving my consent for my code to become a part of TypeIt or any of its related packages, and for it to be used and sold commercially.
