### PR TITLE
Explict callback types in option

### DIFF
--- a/packages/typeit/src/types.ts
+++ b/packages/typeit/src/types.ts
@@ -1,3 +1,5 @@
+import TypeIt from "./TypeIt";
+
 export type Character = {
   node: El | null;
   content: string | Node;
@@ -34,11 +36,11 @@ export interface Options {
   startDelete?: boolean;
   strings?: string[] | string;
   waitUntilVisible?: boolean;
-  beforeString?: Function;
-  afterString?: Function;
-  beforeStep?: Function;
-  afterStep?: Function;
-  afterComplete?: Function;
+  beforeString?: (string: String, instance: TypeIt) => void | ((string: String, instance: TypeIt) => Promise<void>);
+  afterString?: (string: String, instance: TypeIt) => void | ((string: String, instance: TypeIt) => Promise<void>);
+  beforeStep?: (instance: TypeIt) => void | ((instance: TypeIt) => Promise<void>);
+  afterStep?: (instance: TypeIt) => void | ((instance: TypeIt) => Promise<void>);
+  afterComplete?: (instance: TypeIt) => void | ((instance: TypeIt) => Promise<void>);
 }
 
 export interface Statuses {


### PR DESCRIPTION
fix: https://github.com/alexmacarthur/typeit/issues/398
# Description

Improving callback types in option:

```ts
interface Options {
...
  beforeString?: (string: String, instance: TypeIt) => void | ((string: String, instance: TypeIt) => Promise<void>);
  afterString?: (string: String, instance: TypeIt) => void | ((string: String, instance: TypeIt) => Promise<void>);
  beforeStep?: (instance: TypeIt) => void | ((instance: TypeIt) => Promise<void>);
  afterStep?: (instance: TypeIt) => void | ((instance: TypeIt) => Promise<void>);
  afterComplete?: (instance: TypeIt) => void | ((instance: TypeIt) => Promise<void>);
...
}
```

## Type of Change

 - [x] It's a bug fix.
 - [ ] It's a new feature (without breaking changes). 
 - [ ] It's a breaking change.

## Checklist

 - [x] Provided detailed description of the issue above.
 - [ ] Updated tests where appropriate.

## License Agreement

[] By submitting this code, I'm aware that, if merged, it will be used as part of a commercial project. By submitting this pull request, I am aware that I'm giving my consent for my code to become a part of TypeIt or any of its related packages, and for it to be used and sold commercially.
